### PR TITLE
Add HelpFlow logic for icon → about → steps

### DIFF
--- a/frontend/src/app/HelpFlow.tsx
+++ b/frontend/src/app/HelpFlow.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Home as HomeIcon,
+  Utensils,
+  DollarSign,
+  AlertTriangle,
+} from 'react-icons/fe';
+
+type HelpType = 'housing' | 'food' | 'cash' | 'disaster' | null;
+
+export default function HelpFlow() {
+  const [selectedHelp, setSelectedHelp] = useState<HelpType>(null);
+
+  return (
+    <section className="max-w-5xl mx-auto px-6 py-24">
+      {/* -------------------------------------------------- */}
+      {/* STEP 1 — ICON SELECTION                            */}
+      {/* -------------------------------------------------- */}
+      {!selectedHelp && (
+        <div className="space-y-10">
+          <h2 className="text-3xl font-medium">
+            What kind of help are you looking for?
+          </h2>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+            <IconCard
+              icon={<HomeIcon />}
+              label="Housing"
+              hint="Shelter, rent help, temporary housing"
+              onClick={() => setSelectedHelp('housing')}
+            />
+
+            <IconCard
+              icon={<Utensils />}
+              label="Food"
+              hint="Food banks, meal programs, nutrition support"
+              onClick={() => setSelectedHelp('food')}
+            />
+
+            <IconCard
+              icon={<DollarSign />}
+              label="Cash assistance"
+              hint="Emergency cash, relief funds"
+              onClick={() => setSelectedHelp('cash')}
+            />
+
+            <IconCard
+              icon={<AlertTriangle />}
+              label="Disaster recovery"
+              hint="Recovery, temporary aid, rebuilding"
+              onClick={() => setSelectedHelp('disaster')}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* -------------------------------------------------- */}
+      {/* STEP 2 — ABOUT / WHAT HAPPENS NEXT                 */}
+      {/* -------------------------------------------------- */}
+      {selectedHelp && (
+        <div className="mt-24 space-y-12 max-w-3xl">
+          <h2 className="text-3xl font-medium">
+            Here’s how we help you find a place to start
+          </h2>
+
+          <p className="text-lg text-neutral-600">
+            Help Nearby helps you explore assistance programs that may be
+            relevant based on what you share. We organize public information so
+            you can see where to start without guessing.
+          </p>
+
+          {/* STEP FLOW */}
+          <div className="space-y-6">
+            <Step
+              number={1}
+              title="We ask a few simple questions"
+              description="Location and situation help narrow down relevant programs."
+            />
+
+            <Step
+              number={2}
+              title="We show possible starting points"
+              description="You’ll see links to official sites that match your needs."
+            />
+
+            <Step
+              number={3}
+              title="You decide what to explore"
+              description="Applications and decisions always happen on official program websites."
+            />
+          </div>
+
+          {/* TRUST BOUNDARY */}
+          <p className="text-sm text-neutral-500">
+            We don’t collect documents, submit applications, or determine
+            eligibility. This tool is for guidance only.
+          </p>
+
+          {/* NEXT QUESTION PLACEHOLDER */}
+          <div className="pt-6 border-t">
+            <p className="text-lg font-medium">
+              What best describes your situation?
+            </p>
+            <p className="text-sm text-neutral-500">
+              (Next step — options will appear here)
+            </p>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Reusable components                                                        */
+/* -------------------------------------------------------------------------- */
+
+function IconCard({
+  icon,
+  label,
+  hint,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  hint: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="group rounded-xl border border-neutral-300 p-6 text-left hover:border-black transition"
+    >
+      <div className="text-2xl mb-2">{icon}</div>
+      <div className="font-medium">{label}</div>
+      <div className="text-sm text-neutral-500 mt-1">{hint}</div>
+    </button>
+  );
+}
+
+function Step({
+  number,
+  title,
+  description,
+}: {
+  number: number;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex gap-4">
+      <div className="text-neutral-400 font-mono">{number}.</div>
+      <div>
+        <div className="font-medium">{title}</div>
+        <div className="text-neutral-600 text-sm">{description}</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
I added a new component HelpFlow.tsx under frontend/src/app/components/.

It’s logic-only (no animation assumptions, no routing), just the core flow:

• Icon selection (housing / food / cash / disaster) • Transition to “About / What happens next”
• Clear trust boundary + placeholder for the next question

This should be safe to animate however you want (icon exit, content slide-in, etc.). Happy to adjust structure if you want the steps broken differently.